### PR TITLE
docs: fix broken links, typos, and fee equation in restored pages

### DIFF
--- a/general/creator-rewards-and-fees.md
+++ b/general/creator-rewards-and-fees.md
@@ -13,7 +13,11 @@ Please see the [FAQ](faq.md) for detail on finding Token Info pages and collecti
 The Clanker fee is fixed at 20% of LP fees that are collected at the pool level in addition to creator LP fees.&#x20;
 
 $$
-CreatorFee \* 0.2 = SwapFees
+ProtocolFee = CreatorFee \* 0.2
+$$
+
+$$
+SwapFees = CreatorFee + ProtocolFee
 $$
 
 | Creator | Protocol | Total Swap Fee |

--- a/general/faq.md
+++ b/general/faq.md
@@ -79,7 +79,7 @@ For tokens created directly through interaction with the @clanker bot on Farcast
 1. Your latest Farcaster verified address
 2. Your Farcaster custody address (if you do not have any Farcaster verified addresses)
 
-See [#how-do-i-find-my-farcaster-verified-address-custody-address](#how-do-i-find-my-farcaster-verified-address-custody-address "mention") for guidance on finding your creator rewards address.
+See [#how-do-i-find-my-farcaster-verified-address-custody-address-fid](#how-do-i-find-my-farcaster-verified-address-custody-address-fid "mention") for guidance on finding your creator rewards address.
 
 </details>
 

--- a/references/core-contracts.md
+++ b/references/core-contracts.md
@@ -1,9 +1,9 @@
 # Core Contracts
 
-{% content-ref url="/pages/fOTIabyVqIakp48nyHnV" %}
+{% content-ref url="core-contracts/v4.md" %}
 [v4](core-contracts/v4.md)
 {% endcontent-ref %}
 
-{% content-ref url="/pages/JPda6c92ea2Zv7urf2y7" %}
+{% content-ref url="core-contracts/v3.1.md" %}
 [v3.1](core-contracts/v3.1.md)
 {% endcontent-ref %}

--- a/references/core-contracts/v4.md
+++ b/references/core-contracts/v4.md
@@ -8,7 +8,7 @@ Clanker v4 consists of three main contracts that are non-upgradeable and can be 
 
 * **Clanker**: The factory contract responsible for token deployment, triggering pool creation, triggering liquidity placement via the LpLocker, and triggering extensions.
 * [**ClankerFeeLocker**](v4/fee-management-contracts/clankerfeelocker.md): A contract that allows users to view and claim their accumulated token fees. This single contract accrues fees for all tokens deployed on Clanker v4.0.0.
-* [**ClankerToken**](broken://pages/HGVc2v9wR2qwSWuJ3phT): A super-chain compatible ERC20 contract. A new contract is deployed for every call to `deployToken()`.
+* [**ClankerToken**](clankertoken-v3.1.0-and-v4.0.0.md): A super-chain compatible ERC20 contract. A new contract is deployed for every call to `deployToken()`.
 
 Clanker v4 additionally defines four interfaces with which the Clanker factory interfaces:
 
@@ -33,13 +33,13 @@ v4.0
 
 v4.1
 
-* [**ClankerHookV2**](v4/clankerhook/clankerhookdynamicfee.md): The same as ClankerHook but with expanded capabilities including [Pool Extensions](v4/clankerhookv2/pool-extensions.md) and mev modules that can change the applied LP fee.
+* [**ClankerHookV2**](v4/clankerhookv2.md): The same as ClankerHook but with expanded capabilities including [Pool Extensions](v4/clankerhookv2/pool-extensions.md) and mev modules that can change the applied LP fee.
 * [**ClankerHookStaticFeeV2**](v4/clankerhookv2/clankerhookstaticfeev2.md): The same as ClankerHookStaticFee except with ClankerHookV2 as the base instead of ClankerHook.
 * [**ClankerHookDynamicFeeV2**](v4/clankerhookv2/clankerhookdynamicfeev2.md): The same as ClankerHookDynamicFee except with ClankerHookV2 as the base instead of ClankerHook.
 
 #### IClankerLPLockers:
 
-* [**ClankerLpLockerFeeConvesrion**](v4/fee-management-contracts/clankerlplockerfeeconversion.md): A locker implementation which enables 7 different reward recipients to be specified and 7 different initial LP positions to be placed, each able to specify which token they prefer to accumulate fees in. This locker works with the IClankerHook implementations to automatically collect LP fees on every swap and distribute the fees to reward recipients via the ClankerFeeLocker.
+* [**ClankerLpLockerFeeConversion**](v4/fee-management-contracts/clankerlplockerfeeconversion.md): A locker implementation which enables 7 different reward recipients to be specified and 7 different initial LP positions to be placed, each able to specify which token they prefer to accumulate fees in. This locker works with the IClankerHook implementations to automatically collect LP fees on every swap and distribute the fees to reward recipients via the ClankerFeeLocker.
 
 #### IClankerExtensions:
 
@@ -52,10 +52,10 @@ v4.1
 
 v4.0
 
-* [**ClankerMevModule2BlockDelay**](v4/mev-modules.md): A MEV module which makes the pool non-swappable for the first 2 blocks after deployment. This prevents people from front-running deployments in the same block of creation.
+* [**ClankerMevModule2BlockDelay**](v4/mev-modules/clankermevmodule2blockdelay.md): A MEV module which makes the pool non-swappable for the first 2 blocks after deployment. This prevents people from front-running deployments in the same block of creation.
 * [**ClankerSniperAuctionV0**](v4/mev-modules/clankersniperauctionv0.md): A MEV module for priority ordered L2s that auctions off the first swaps on a block, directing the auction fees to token creators.&#x20;
 
 v4.1
 
-* [**ClankerMevDescendingFees**](v4/mev-modules/clankermevdescendingfees.md): A MEV module which enables deployers to select a starting LP fee (up to 80%), an ending fee, and a duration to decay the fee over (max 2 mintues). The fee descends parabolically.&#x20;
+* [**ClankerMevDescendingFees**](v4/mev-modules/clankermevdescendingfees.md): A MEV module which enables deployers to select a starting LP fee (up to 80%), an ending fee, and a duration to decay the fee over (max 2 minutes). The fee descends parabolically.&#x20;
 * [**ClankerSniperAuctionV2**](v4/mev-modules/clankersniperauctionv2.md): The same as ClankerSniperAuctionV0 but with the fee behavior of ClankerMevDescendingFees. Auctioned swaps pay the starting fee and the fee descent starts after the auction ends.

--- a/references/core-contracts/v4/clankerhook.md
+++ b/references/core-contracts/v4/clankerhook.md
@@ -6,7 +6,7 @@ The **ClankerHook** contract itself facilitates:
 
 * Automatic fee collection of the initial LP position's fees. Fees are collected by the **IClankerLpLocker** contracts and are routed to the [**ClankerFeeLocker**](fee-management-contracts/clankerfeelocker.md) contract for users to claim.
 * Collection of a DEX-level protocol fee, separate from the creator LP fees, always in the paired token.
-* Triggering of a pool's `MevModule` until it is disabled or expired. Mev Modules can run for up to 2 mintues max.
+* Triggering of a pool's `MevModule` until it is disabled or expired. Mev Modules can run for up to 2 minutes max.
 
 Note: both of the fee collection mechanisms lag by a swap, so the fees collected in a swap are the fees from the previous swap. This is because a swap's fees are only sent into the `PoolManager` contract after the swap has completed.
 

--- a/references/core-contracts/v4/mev-modules.md
+++ b/references/core-contracts/v4/mev-modules.md
@@ -19,5 +19,5 @@ Clanker has four mev modules currently written:
 
 **v4.1, ClankerHookV2**:
 
-* [**ClankerMevDescendingFees**](mev-modules/clankermevdescendingfees.md): A MEV module which enables deployers to select a starting LP fee (up to 80%), an ending fee, and a duration to decay the fee over (max 2 mintues). The fee descends parabolically. Only compatible with **ClankerHookV2**.
+* [**ClankerMevDescendingFees**](mev-modules/clankermevdescendingfees.md): A MEV module which enables deployers to select a starting LP fee (up to 80%), an ending fee, and a duration to decay the fee over (max 2 minutes). The fee descends parabolically. Only compatible with **ClankerHookV2**.
 * [**ClankerSniperAuctionV2**](mev-modules/clankersniperauctionv2.md): The same as ClankerSniperAuctionV0 but with the fee behavior of ClankerMevDescendingFees. Auctioned swaps pay the starting fee and the fee descent starts after the auction ends. Only compatible with **ClankerHookV2**.


### PR DESCRIPTION
## Summary

Follow-up to #8. Fixes the two source-side bugs called out in #8's own body plus a handful of related issues surfaced during audit.

**Broken links**

- `references/core-contracts/v4.md:11` — `broken://pages/HGVc2v9wR2qwSWuJ3phT` on ClankerToken bullet → `clankertoken-v3.1.0-and-v4.0.0.md`
- `references/core-contracts/v4.md:36` — ClankerHookV2 was pointing at `clankerhookdynamicfee.md` → `v4/clankerhookv2.md`
- `references/core-contracts/v4.md:55` — ClankerMevModule2BlockDelay was pointing at the mev-modules index → specific page `v4/mev-modules/clankermevmodule2blockdelay.md`
- `references/core-contracts.md:3,7` — two `{% content-ref url="/pages/{hash}" %}` revision-style URLs rewritten to `core-contracts/v4.md` and `core-contracts/v3.1.md`
- `general/faq.md:82` — mention anchor was missing the `-fid` suffix, mismatching the same anchor on line 25 and the actual `<summary>` slug on line 88

**Content correction (from Bugbot review on #8)**

- `general/creator-rewards-and-fees.md` — displayed equation `CreatorFee * 0.2 = SwapFees` was wrong: that product is the protocol fee, not the total swap fee. Replaced with two equations that match the table (`ProtocolFee = CreatorFee * 0.2` and `SwapFees = CreatorFee + ProtocolFee`).

**Typos**

- `references/core-contracts/v4.md:42` — `ClankerLpLockerFeeConvesrion` → `ClankerLpLockerFeeConversion` (visible label; target file is correct)
- `references/core-contracts/v4.md:60` and `references/core-contracts/v4/mev-modules.md:22` — `max 2 mintues` → `max 2 minutes`

## Base branch

Targeting `docs/restore-pages` so this stacks on #8 and reviews as a small diff. GitHub will auto-retarget to `main` when #8 merges.

## Test plan

- [ ] All updated markdown links resolve to real files on disk (verified locally)
- [ ] GitBook sync renders both equations in Creator Rewards & Fees and the fee table still lines up with them
- [ ] FAQ "verified address / custody address / FID" mention resolves from both L25 and L82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or contract impact.
> 
> **Overview**
> Documentation follow-up that repairs navigation and corrects how **Clanker protocol vs swap fees** are described.
> 
> **Creator Rewards & Fees** replaces a wrong single equation (`CreatorFee * 0.2 = SwapFees`) with **`ProtocolFee = CreatorFee * 0.2`** and **`SwapFees = CreatorFee + ProtocolFee`**, aligned with the fee table.
> 
> **Core Contracts** and **v4** docs swap broken GitBook `/pages/{hash}` and `broken://` URLs for real relative paths (ClankerToken, ClankerHookV2, MEV module pages, v3.1/v4 index refs). The FAQ internal mention anchor now includes **`-fid`** so it matches the target heading.
> 
> Minor copy fixes: **FeeConversion** spelling, and **“2 minutes”** typos in hook/MEV docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157923df3ffba870344a9fa6cf336e94dedb5a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->