### PR TITLE
docs: remove deleted /api/tokens/{address}/holders endpoint

### DIFF
--- a/api-reference/public/README.md
+++ b/api-reference/public/README.md
@@ -16,7 +16,6 @@ These endpoints are publicly accessible and require no authentication.
 - `POST /api/tokens/fetch-by-pool-addresses` — Returns token data for multiple pool addresses (max 100).
 - `GET /api/tokens/search` — Search tokens by query or FIDs. *(deprecated)*
 - `GET /api/tokens/estimate-rewards-by-pool-address` — Estimate uncollected rewards for a pool. *(deprecated)*
-- `GET /api/tokens/{address}/holders` — Returns holder count and top-10 concentration for a token.
 
 ### Users
 

--- a/api-reference/public/tokens.md
+++ b/api-reference/public/tokens.md
@@ -203,36 +203,3 @@ Search tokens by query or FIDs.
 Estimate uncollected rewards for a pool.
 
 **Authentication:** Public
-
----
-
-### GET `/api/tokens/{address}/holders`
-
-Returns holder count and top-10 concentration for a token.
-
-**Authentication:** Public
-
-**Path Parameters**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `address` | `address` | Yes | — | Token contract address. |
-
-**Query Parameters**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `chain` | `number` | No | 8453 | Chain ID (defaults to Base). |
-
-**Response:** Holder statistics.
-
-```json
-{
-  "totalHolders": 4521,
-  "top10Sum": 45.2
-}
-```
-
-> Cached for 5 minutes.
-
----


### PR DESCRIPTION
## Summary

Companion to **clanker-devco/clanker.world#1686**, which deletes the `/api/tokens/{address}/holders` route.

That route is dead — zero requests over the retained Vercel log window, no frontend usage (the app calls `getHolders` in-process), and an org-wide code search found no SDK or client that hits it. With the endpoint removed, the public API reference should no longer document it.

## Changes

- Remove the `GET /api/tokens/{address}/holders` section from `api-reference/public/tokens.md`
- Remove its bullet from `api-reference/public/README.md`

Prose mentions of "token holders" (e.g. in `general/creator-rewards-and-fees.md`) are unrelated and left as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or client contract changes beyond aligning docs with a removed unused endpoint.
> 
> **Overview**
> Removes public API documentation for **`GET /api/tokens/{address}/holders`**, which was deleted in the companion backend PR.
> 
> The endpoint bullet is dropped from `api-reference/public/README.md`, and the full section (path/query params, sample response, 5-minute cache note) is removed from `api-reference/public/tokens.md`. Other docs that mention “token holders” in prose are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d7ce41217684cc176158810258244df5bb9590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->