### PR TITLE
docs: add @clanker support & marketing account to core team

### DIFF
--- a/general/token-deployments/deploying-a-token.md
+++ b/general/token-deployments/deploying-a-token.md
@@ -12,6 +12,6 @@ Clanker will reply to the cast with one of three responses:
 2. If the request is not clear to Clanker, Clanker will respond with clarifying questions in order to determine the token name, ticker, and whether the creator wants to deploy the token.
 3. If the creator is unable to deploy a token for various reasons, Clanker will respond with the cast with the reason.
 
-[^1]: Don't have a Farcaster account? You can sign up using [Warpcast](https://warpcast.com/)!\
+[^1]: Don't have a Farcaster account? You can sign up at [farcaster.xyz](https://farcaster.xyz/)!\
     \
     Alternatively, uou can also visit our friends at [Super](https://www.supercast.xyz/) and  [NewCaster](https://newcaster.org/) to create a Farcaster account.

--- a/references/core-team.md
+++ b/references/core-team.md
@@ -2,4 +2,4 @@
 
 * Veganbeef: [Farcaster](https://farcaster.xyz/veganbeef)
 * Quazia: [Farcaster](https://farcaster.xyz/quazia)
-* @clanker: [Farcaster](https://farcaster.xyz/clanker) — general support & marketing
+* Clanker Support & Marketing: [Farcaster](https://farcaster.xyz/clanker)

--- a/references/core-team.md
+++ b/references/core-team.md
@@ -1,5 +1,5 @@
 # Core Team
 
-* Veganbeef: [Farcaster](https://warpcast.com/veganbeef)
-* Quazia: [Farcaster](https://warpcast.com/quazia)
-* @clanker: [Farcaster](https://warpcast.com/clanker) — general support & marketing
+* Veganbeef: [Farcaster](https://farcaster.xyz/veganbeef)
+* Quazia: [Farcaster](https://farcaster.xyz/quazia)
+* @clanker: [Farcaster](https://farcaster.xyz/clanker) — general support & marketing

--- a/references/core-team.md
+++ b/references/core-team.md
@@ -2,3 +2,4 @@
 
 * Veganbeef: [Farcaster](https://warpcast.com/veganbeef)
 * Quazia: [Farcaster](https://warpcast.com/quazia)
+* @clanker: [Farcaster](https://warpcast.com/clanker) — general support & marketing


### PR DESCRIPTION
Two related updates to the docs:

- **Core Team page** (`references/core-team.md`): added the `@clanker` Farcaster account, tagged as **general support & marketing**, alongside Veganbeef and Quazia.
- **Farcaster URLs**: updated all `warpcast.com` links to `farcaster.xyz` across the docs — the three Core Team entries and the sign-up footnote in `general/token-deployments/deploying-a-token.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and team listing updates with no runtime or security impact.
> 
> **Overview**
> **Core Team** (`references/core-team.md`) adds **Clanker Support & Marketing** with a Farcaster link to `@clanker`, and updates Veganbeef and Quazia profile URLs from `warpcast.com` to `farcaster.xyz`.
> 
> The **deploying a token** footnote in `general/token-deployments/deploying-a-token.md` points new users to [farcaster.xyz](https://farcaster.xyz/) for sign-up instead of Warpcast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e0b7d14911fb7244f22b96d5e311b6e65d1542d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->